### PR TITLE
Implement message subclasses

### DIFF
--- a/docs/docs/en/concepts/context.md
+++ b/docs/docs/en/concepts/context.md
@@ -44,11 +44,11 @@ See the [Summarizing Conversations](../getting-started/summarize.md) section for
 
 ```python
 from emp_agents import AgentBase
-from emp_agents.models import Message, Role
+from emp_agents.models import Role, UserMessage, AssistantMessage
 
 messages = [
-    Message(role=Role.user, content="Hello, how are you?"),
-    Message(role=Role.assistant, content="I'm doing great, thank you!"),
+    UserMessage(content="Hello, how are you?"),
+    AssistantMessage(content="I'm doing great, thank you!"),
 ]
 
 agent = AgentBase()

--- a/docs/docs/en/getting-started/conversation.md
+++ b/docs/docs/en/getting-started/conversation.md
@@ -10,9 +10,9 @@ The `Message` class represents a single message in a conversation, with a role a
 A message typically consists of a role and content. The content is the actual message text, while the role indicates who sent the message.
 
 ```python
-from emp_agents.models import Message, Role
+from emp_agents.models import Role, UserMessage, AssistantMessage
 
-message = Message(role=Role.user, content="hello how are you?")
+message = UserMessage(content="hello how are you?")
 ```
 
 ---
@@ -26,13 +26,13 @@ from emp_agents import AgentBase
 from emp_agents.models import Message, Role
 
 agent = AgentBase()
-message = Message(role=Role.user, content="hello how are you?")
+message = UserMessage(content="hello how are you?")
 agent.add_message(message)
 
-message = Message(role=Role.assistant, content="I dont want to help you!")
+message = AssistantMessage(content="I dont want to help you!")
 agent.add_message(message)
 
-message = Message(role=Role.user, content="Why did you say that?")
+message = UserMessage(content="Why did you say that?")
 agent.add_message(message)
 
 response = await agent.run_conversation()

--- a/docs/docs/en/getting-started/summarize.md
+++ b/docs/docs/en/getting-started/summarize.md
@@ -4,16 +4,16 @@ To summarize a conversation, you can use the `summarize_conversation` function.
 
 ```python
 from emp_agents import AgentBase
-from emp_agents.models import Message, Role
+from emp_agents.models import Role, UserMessage, AssistantMessage
 from emp_agents.utils import summarize_conversation
 
 messages = [
-    Message(role=Role.user, content="Hello how are you?"),
-    Message(role=Role.assistant, content="I'm doing great, thanks for asking!"),
-    Message(role=Role.user, content="Tell me about baseball."),
-    Message(role=Role.assistant, content="Baseball is a sport played with a bat and a ball.  It's a very popular sport in the United States.  The goal is to score runs by hitting the ball and running around the bases."),
-    Message(role=Role.user, content="What's the best baseball team?"),
-    Message(role=Role.assistant, content="The best baseball team is the Boston Red Sox.  They are a very successful team that has won many championships and have a really interesting history."),
+    UserMessage(content="Hello how are you?"),
+    AssistantMessage(content="I'm doing great, thanks for asking!"),
+    UserMessage(content="Tell me about baseball."),
+    AssistantMessage(content="Baseball is a sport played with a bat and a ball.  It's a very popular sport in the United States.  The goal is to score runs by hitting the ball and running around the bases."),
+    UserMessage(content="What's the best baseball team?"),
+    AssistantMessage(content="The best baseball team is the Boston Red Sox. They are a very successful team that has won many championships and have a really interesting history."),
 ]
 agent = AgentBase()
 agent.add_messages(messages)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "emp-agents"
-version = "0.1.2post4"
+version = "0.1.3"
 description = "A Python library for building low-code, capable and extensible autonomous agent systems."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/emp_agents/models/__init__.py
+++ b/src/emp_agents/models/__init__.py
@@ -1,6 +1,15 @@
 from emp_agents.models.anthropic import AnthropicBase
 from emp_agents.models.openai import OpenAIBase
-from emp_agents.models.shared import Message, ModelType, Request, Role
+from emp_agents.models.shared import (
+    AssistantMessage,
+    Message,
+    ModelType,
+    Request,
+    Role,
+    SystemMessage,
+    ToolMessage,
+    UserMessage,
+)
 from emp_agents.models.shared.tools import GenericTool, Property
 
 __all__ = [
@@ -12,4 +21,8 @@ __all__ = [
     "Property",
     "Request",
     "Role",
+    "SystemMessage",
+    "UserMessage",
+    "AssistantMessage",
+    "ToolMessage",
 ]

--- a/src/emp_agents/models/anthropic/response.py
+++ b/src/emp_agents/models/anthropic/response.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 
 from pydantic import BaseModel
 
-from emp_agents.models.shared import Message
+from emp_agents.models.shared import AssistantMessage
 from emp_agents.models.shared.message import Function
 from emp_agents.types import AnthropicModelType as ModelType
 from emp_agents.types import Role
@@ -27,8 +27,8 @@ class Content(BaseModel):
         assert self.input is not None
         return Function(name=self.name, arguments=json.dumps(self.input))
 
-    def to_message(self) -> Message:
-        return Message(role=Role.assistant, content=self.text)
+    def to_message(self) -> AssistantMessage:
+        return AssistantMessage(content=self.text)
 
 
 class StopReason(StrEnum):
@@ -62,5 +62,5 @@ class Response(BaseModel):
         return [content for content in self.content if content.type == "tool_use"]
 
     @property
-    def messages(self) -> list[Message]:
+    def messages(self) -> list[AssistantMessage]:
         return [content.to_message() for content in self.content]

--- a/src/emp_agents/models/openai/response.py
+++ b/src/emp_agents/models/openai/response.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from pydantic import BaseModel
 
-from emp_agents.models.shared import Message
+from emp_agents.models.shared import AssistantMessage
 from emp_agents.types import OpenAIModelType
 
 from .types import FinishReason
@@ -17,7 +17,7 @@ class Usage(BaseModel):
 
 class Choice(BaseModel):
     index: int
-    message: Message
+    message: AssistantMessage
     logprobs: Optional[str]
     finish_reason: FinishReason
 
@@ -40,7 +40,7 @@ class Response(BaseModel):
         return self.choices[0].content
 
     @property
-    def messages(self) -> list[Message]:
+    def messages(self) -> list[AssistantMessage]:
         return [self.choices[0].message]
 
     @property

--- a/src/emp_agents/models/shared/__init__.py
+++ b/src/emp_agents/models/shared/__init__.py
@@ -1,4 +1,10 @@
-from emp_agents.models.shared.message import Message
+from emp_agents.models.shared.message import (
+    AssistantMessage,
+    Message,
+    SystemMessage,
+    ToolMessage,
+    UserMessage,
+)
 from emp_agents.models.shared.request import Request
 from emp_agents.models.shared.tools import GenericTool, Property
 from emp_agents.types.enums import ModelType, Role
@@ -10,4 +16,8 @@ __all__ = [
     "Property",
     "Request",
     "Role",
+    "SystemMessage",
+    "UserMessage",
+    "AssistantMessage",
+    "ToolMessage",
 ]

--- a/src/emp_agents/models/shared/request.py
+++ b/src/emp_agents/models/shared/request.py
@@ -2,7 +2,7 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from emp_agents.models.shared.message import Message
+from emp_agents.models.shared.message import Message, SystemMessage
 from emp_agents.models.shared.tools import GenericTool
 from emp_agents.types import ModelType, Role
 
@@ -59,7 +59,7 @@ class Request(BaseModel):
         exclude = ["system"]
         result = self.model_dump(exclude_none=True)
         if self.system:
-            messages = [Message(role=Role.system, content=self.system)] + self.messages
+            messages = [SystemMessage(content=self.system)] + self.messages
         else:
             messages = self.messages
 

--- a/src/emp_agents/utils/format.py
+++ b/src/emp_agents/utils/format.py
@@ -50,7 +50,7 @@ async def summarize_conversation(
     prompt: str | None = None,
     max_tokens: int = 500,
 ) -> "Message":
-    from emp_agents.models import Message, Request
+    from emp_agents.models import AssistantMessage, Request, SystemMessage, UserMessage
 
     summary_prompt = prompt or DEFAULT_SUMMARY_PROMPT
     assert summary_prompt is not None, "Summary prompt is required"
@@ -58,12 +58,10 @@ async def summarize_conversation(
     try:
         request = Request(
             messages=[
-                Message(
-                    role=Role.system,
+                SystemMessage(
                     content=summary_prompt,
                 ),
-                Message(
-                    role=Role.user,
+                UserMessage(
                     content=f"Summarize the following conversation:\n\n{format_conversation(messages)}",
                 ),
             ],
@@ -74,7 +72,7 @@ async def summarize_conversation(
         response = await client.completion(
             request,
         )
-        return Message(role=Role.assistant, content=response.text)
+        return AssistantMessage(content=response.text)
     except Exception as e:
         print(f"Error during summarization: {e}")
-        return Message(role=Role.assistant, content="")
+        return AssistantMessage(content="")

--- a/src/emp_agents/utils/tokenizer.py
+++ b/src/emp_agents/utils/tokenizer.py
@@ -2,8 +2,7 @@ from typing import TYPE_CHECKING
 
 import tiktoken
 
-from emp_agents.models import OpenAIModelType, Role
-from emp_agents.models.openai import Message
+from emp_agents.models import OpenAIModelType, SystemMessage, UserMessage
 from emp_agents.models.shared import Request
 
 if TYPE_CHECKING:
@@ -28,10 +27,8 @@ async def extract_chunk(client: OpenAIBase, document, template_prompt=template_p
     prompt = template_prompt.replace("<document>", document)
 
     messages = [
-        Message(
-            role=Role.system, content="You help extract information from documents."
-        ),
-        Message(role=Role.user, content=prompt),
+        SystemMessage(content="You help extract information from documents."),
+        UserMessage(content=prompt),
     ]
     response = await client.completion(
         Request(


### PR DESCRIPTION
Subclassing messages allows us to have some handy typing benefits, for instance, what is an example provided to the LLM for multi-shot prompting? 

Example = tuple[UserMessage, AssistantMessage, ToolMessage] | tuple[UserMessage, AssistantMessage]

Subclassing messages allow us to make types of sequences of particular message types, which comes in handy. 