### PR TITLE
bump completion token limits

### DIFF
--- a/src/emp_agents/models/shared/request.py
+++ b/src/emp_agents/models/shared/request.py
@@ -2,7 +2,7 @@ from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from emp_agents.models.shared.message import Message, SystemMessage, UserMessage
+from emp_agents.models.shared.message import Message, SystemMessage
 from emp_agents.models.shared.tools import GenericTool
 from emp_agents.types import ModelType, OpenAIModelType, Role
 
@@ -15,7 +15,7 @@ class Request(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     model: ModelType
-    max_tokens: Optional[int] = Field(default=1_000, lt=16_384, gt=0)
+    max_tokens: Optional[int] = Field(default=4096, lt=128_000, gt=0)
     temperature: Optional[float] = Field(default=None, ge=0, le=2.0)
     tool_choice: Literal["none", "required", "auto", None] = Field(default=None)
     tools: Optional[list[GenericTool]] = None


### PR DESCRIPTION
For o1 - we want to at least set token limit to 64k. the max cap here is way too low, default felt low too. 